### PR TITLE
Add secure n8n workflow integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,8 @@ DATABASE_URL="postgresql://postgres:password@localhost:5432/nextjs-supabase-temp
 NEXT_PUBLIC_SUPABASE_URL=""
 NEXT_PUBLIC_SUPABASE_ANON_KEY=""
 
+# n8n Integration
+N8N_BASE_URL="https://your-n8n-instance.railway.app"
+N8N_WEBHOOK_SECRET="your-secure-shared-secret-at-least-32-chars"
+N8N_TIMEOUT=30000
+

--- a/docs/n8n-integration.md
+++ b/docs/n8n-integration.md
@@ -1,0 +1,34 @@
+# n8n Integration Guide
+
+This project connects your Next.js + tRPC backend with n8n workflows. Each workflow is triggered via a secure server-to-server call so your n8n instance remains hidden from the browser.
+
+## Environment Setup
+
+Add the following to your `.env` file and update with your values:
+
+```bash
+N8N_BASE_URL="https://your-n8n-instance.railway.app"
+N8N_WEBHOOK_SECRET="your-secure-shared-secret-at-least-32-chars"
+N8N_TIMEOUT=30000
+```
+
+## Adding a New Workflow
+
+1. Copy `src/server/api/routers/n8n/workflows/template.ts` to a new file under `workflows/`.
+2. Rename the router and procedure names to match your workflow.
+3. Update the webhook `endpoint` to the n8n URL path.
+4. Define the input schema with Zod.
+5. Export the router and add it to `src/server/api/routers/n8n/index.ts`.
+6. Call it from the frontend using `clientApi.n8n.<workflow>.<procedure>.useMutation()`.
+
+## Testing Workflows
+
+- Use the demo page at `/n8n-demo` as a reference.
+- Mock responses from n8n during development if needed.
+- All errors are surfaced via `TRPCError` so the UI receives meaningful messages.
+
+## Troubleshooting
+
+- Ensure the webhook secret matches between this app and your n8n instance.
+- Check console logs for `[n8n]` messages which include request and response details.
+- Timeouts result in a `TIMEOUT` error—adjust `N8N_TIMEOUT` if necessary.

--- a/docs/workflow-examples.md
+++ b/docs/workflow-examples.md
@@ -1,0 +1,30 @@
+# Workflow Examples
+
+This document showcases example payloads and responses when calling n8n workflows from tRPC.
+
+## Example Input
+
+```typescript
+clientApi.n8n.template.processTemplate.mutate({
+  data: { sample: "data" },
+  action: "process"
+});
+```
+
+## Example Output
+
+```json
+{
+  "success": true,
+  "data": { "result": "ok" },
+  "message": "Processed"
+}
+```
+
+## Error Handling
+
+- `BAD_REQUEST` – Input validation failed or n8n returned 400
+- `TIMEOUT` – Workflow exceeded the timeout defined by `N8N_TIMEOUT`
+- `INTERNAL_SERVER_ERROR` – n8n encountered an error
+
+Use these patterns when designing your own workflows to keep responses consistent.

--- a/src/app/n8n-demo/client-page.tsx
+++ b/src/app/n8n-demo/client-page.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useState } from "react";
+import { clientApi } from "~/trpc/react";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { toast } from "sonner";
+
+export function N8nDemoClient() {
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const { mutate: processWorkflow } = clientApi.n8n.template.processTemplate.useMutation({
+    onSuccess: () => {
+      toast.success("Workflow completed successfully!");
+      setIsProcessing(false);
+    },
+    onError: (error) => {
+      toast.error(`Workflow failed: ${error.message}`);
+      setIsProcessing(false);
+    },
+  });
+
+  const handleProcessWorkflow = () => {
+    setIsProcessing(true);
+    processWorkflow({
+      data: { sample: "data" },
+      action: "process",
+    });
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center">
+      <Card className="max-w-[400px]">
+        <CardHeader>
+          <CardTitle>n8n Workflow Demo</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={handleProcessWorkflow} disabled={isProcessing} className="w-full">
+            {isProcessing ? "Processing..." : "Run n8n Workflow"}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/n8n-demo/page.tsx
+++ b/src/app/n8n-demo/page.tsx
@@ -1,0 +1,6 @@
+import { serverApi } from "~/trpc/server";
+import { N8nDemoClient } from "./client-page";
+
+export default async function N8nDemoPage() {
+  return <N8nDemoClient />;
+}

--- a/src/env.js
+++ b/src/env.js
@@ -17,6 +17,9 @@ export const env = createEnv({
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
+    N8N_BASE_URL: z.string().url(),
+    N8N_WEBHOOK_SECRET: z.string().min(32),
+    N8N_TIMEOUT: z.coerce.number().default(30000),
   },
 
   /**
@@ -38,6 +41,9 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    N8N_BASE_URL: process.env.N8N_BASE_URL,
+    N8N_WEBHOOK_SECRET: process.env.N8N_WEBHOOK_SECRET,
+    N8N_TIMEOUT: process.env.N8N_TIMEOUT,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/lib/n8n-client.ts
+++ b/src/lib/n8n-client.ts
@@ -1,0 +1,89 @@
+import { TRPCError } from "@trpc/server";
+import { env } from "~/env";
+
+export interface CallWorkflowOptions {
+  endpoint: string;
+  payload: unknown;
+  user?: { id: string; email?: string | null };
+}
+
+export interface N8nWorkflowResponse<T = unknown> {
+  success: boolean;
+  data: T;
+  message?: string;
+}
+
+class N8nClient {
+  private baseUrl = env.N8N_BASE_URL;
+  private secret = env.N8N_WEBHOOK_SECRET;
+  private timeout = env.N8N_TIMEOUT;
+
+  async callWorkflow<T>(opts: CallWorkflowOptions): Promise<N8nWorkflowResponse<T>> {
+    const url = `${this.baseUrl}${opts.endpoint}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeout);
+
+    const body = {
+      ...(opts.user ? { user_id: opts.user.id, user_email: opts.user.email } : {}),
+      ...opts.payload,
+    };
+
+    try {
+      console.info(`[n8n] calling workflow`, { url, body });
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-webhook-secret": this.secret,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+
+      if (res.status === 408) {
+        throw new TRPCError({
+          code: "TIMEOUT",
+          message: "n8n workflow timed out, please try again",
+        });
+      }
+      if (res.status === 400) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid data sent to n8n workflow",
+        });
+      }
+      if (res.status >= 500) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "n8n workflow failed to execute",
+        });
+      }
+      if (!res.ok) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Failed to call n8n workflow",
+        });
+      }
+
+      const json = (await res.json()) as N8nWorkflowResponse<T>;
+      console.info(`[n8n] workflow response`, { url, status: res.status, json });
+      return json;
+    } catch (err) {
+      if (err instanceof TRPCError) throw err;
+      if ((err as Error).name === "AbortError") {
+        throw new TRPCError({
+          code: "TIMEOUT",
+          message: "n8n workflow timed out, please try again",
+        });
+      }
+      console.error(`[n8n] unexpected error`, err);
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Unexpected n8n error",
+      });
+    }
+  }
+}
+
+export const n8nClient = new N8nClient();

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,4 +1,5 @@
 import { exampleRouter } from "~/server/api/routers/example";
+import { n8nRouter } from "~/server/api/routers/n8n";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -8,6 +9,7 @@ import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
  */
 export const appRouter = createTRPCRouter({
   example: exampleRouter,
+  n8n: n8nRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/n8n/base.ts
+++ b/src/server/api/routers/n8n/base.ts
@@ -1,0 +1,24 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+import { authroizedProcedure } from "~/server/api/trpc";
+import { n8nClient } from "~/lib/n8n-client";
+
+export const n8nProcedure = authroizedProcedure.use(async ({ ctx, next }) => {
+  return next({
+    ctx: {
+      ...ctx,
+      n8nClient,
+    },
+  });
+});
+
+export const n8nRequestSchema = z.object({
+  workflowData: z.any(),
+  workflowType: z.string(),
+});
+
+export const n8nResponseSchema = z.object({
+  success: z.boolean(),
+  data: z.any(),
+  message: z.string().optional(),
+});

--- a/src/server/api/routers/n8n/index.ts
+++ b/src/server/api/routers/n8n/index.ts
@@ -1,0 +1,6 @@
+import { createTRPCRouter } from "~/server/api/trpc";
+import { templateRouter } from "./workflows/template";
+
+export const n8nRouter = createTRPCRouter({
+  template: templateRouter,
+});

--- a/src/server/api/routers/n8n/types.ts
+++ b/src/server/api/routers/n8n/types.ts
@@ -1,0 +1,10 @@
+export interface WorkflowCallInput {
+  endpoint: string;
+  payload: unknown;
+}
+
+export interface WorkflowCallResult<T = unknown> {
+  success: boolean;
+  data: T;
+  message?: string;
+}

--- a/src/server/api/routers/n8n/workflows/template.ts
+++ b/src/server/api/routers/n8n/workflows/template.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { n8nProcedure } from "../base";
+import { createTRPCRouter } from "~/server/api/trpc";
+
+export const templateRouter = createTRPCRouter({
+  processTemplate: n8nProcedure
+    .input(
+      z.object({
+        data: z.any(),
+        action: z.string(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      const result = await ctx.n8nClient.callWorkflow({
+        endpoint: "/webhook/your-n8n-endpoint",
+        payload: {
+          user_id: ctx.supabaseUser.id,
+          user_email: ctx.supabaseUser.email,
+          ...input,
+        },
+      });
+
+      return result;
+    }),
+});


### PR DESCRIPTION
## Summary
- extend environment validation for n8n integration
- add n8n client library with TRPC error handling
- add modular n8n router system and example workflow
- expose n8n router in app router
- create demo page and docs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f58bffc98832caa4cb3d0d06465ca