### PR TITLE
Add n8n workflow wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ This template doesn't enforce an opinion on data fetching strategies, but you do
 There is lengthy debate on what the right approach will be for each use case. I encourage you to think critically about what one is best for you. If you're not sure, try starting with the TanStack query option and try pre-fetching queries in the server component for the page.
 
 You can see examples in `prefetch/page.tsx`, `server-only-fetch/page.tsx`, and `client-only-fetch/page.tsx`. It's also worth noting that you can pre-fetch data in the initial SSR render of client components too, but I digress.
+
+## n8n Workflows
+
+The `n8nProcedure` middleware now wraps `n8nClient.callWorkflow` and injects the authenticated Supabase user automatically. When calling `ctx.n8n.callWorkflow`, you only provide workflow specific options; the current user id and email are added for you.
+

--- a/src/server/api/routers/n8n/base.ts
+++ b/src/server/api/routers/n8n/base.ts
@@ -1,0 +1,33 @@
+import {
+  authroizedProcedure,
+  createTRPCRouter,
+} from "~/server/api/trpc";
+import { n8nClient, type CallWorkflowOptions } from "~/server/n8n/client";
+
+export const n8nRouter = createTRPCRouter({});
+
+const n8nMiddleware = authroizedProcedure.use(async ({ ctx, next }) => {
+  const callWorkflow = (
+    id: string,
+    options: Omit<CallWorkflowOptions, "user">
+  ) =>
+    n8nClient.callWorkflow(id, {
+      ...options,
+      user: { id: ctx.supabaseUser.id, email: ctx.supabaseUser.email },
+    });
+
+  return next({
+    ctx: { ...ctx, n8n: { callWorkflow } },
+  });
+});
+
+export const n8nProcedure = authroizedProcedure.use(n8nMiddleware);
+
+export type N8nContext = {
+  n8n: {
+    callWorkflow: (
+      id: string,
+      options: Omit<CallWorkflowOptions, "user">
+    ) => Promise<unknown>;
+  };
+};

--- a/src/server/n8n/client.ts
+++ b/src/server/n8n/client.ts
@@ -1,0 +1,12 @@
+export interface CallWorkflowOptions {
+  user?: { id: string; email: string };
+  [key: string]: unknown;
+}
+
+export const n8nClient = {
+  async callWorkflow(workflowId: string, options: CallWorkflowOptions) {
+    // Placeholder for actual n8n workflow call
+    console.log("Calling workflow", workflowId, options);
+    return { workflowId, ...options };
+  },
+};

--- a/workflows/template.ts
+++ b/workflows/template.ts
@@ -1,0 +1,10 @@
+import type { CallWorkflowOptions } from "~/server/n8n/client";
+import type { N8nContext } from "~/server/api/routers/n8n/base";
+
+export const runTemplateWorkflow = async (
+  ctx: N8nContext,
+  data: Record<string, unknown>,
+) => {
+  // The wrapper on ctx.n8n will inject the user automatically
+  return ctx.n8n.callWorkflow("template", { payload: data });
+};


### PR DESCRIPTION
## Summary
- introduce `n8nClient` and `CallWorkflowOptions`
- expose `n8nProcedure` middleware with automatic user injection
- create example workflow helper
- document automatic user injection for n8n workflows

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5ca95e40832ca5bdc91815c7e160