### PR TITLE
Fix n8nProcedure ctx.supabaseUser type

### DIFF
--- a/src/server/api/routers/n8n/base.ts
+++ b/src/server/api/routers/n8n/base.ts
@@ -9,7 +9,13 @@ export const n8nProcedure = authorizedProcedure.use(async ({ ctx, next }) => {
     callWorkflow: (opts: Omit<CallWorkflowOptions, "user">) =>
       n8nClient.callWorkflow({
         ...opts,
-        user: { id: ctx.supabaseUser.id, email: ctx.supabaseUser.email },
+        // `authorizedProcedure` guarantees a `supabaseUser` is present, but the
+        // context type still allows `null`. Use a non-null assertion here to
+        // satisfy TypeScript while keeping the runtime check centralized.
+        user: {
+          id: ctx.supabaseUser!.id,
+          email: ctx.supabaseUser!.email,
+        },
       }),
   } as typeof n8nClient;
 


### PR DESCRIPTION
## Summary
- ensure `ctx.supabaseUser` is non-null for n8n workflow calls

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f6b7f4234832c872151904ee3eea8