### PR TITLE
Add internal DB support & demo integrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@
 # Prisma
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
 DATABASE_URL="postgresql://postgres:password@localhost:5432/nextjs-supabase-template"
+INTERNAL_DATABASE_URL="postgresql://postgres:password@localhost:5432/internal-db"
 
 # Supabase
 # https://supabase.com/docs/guides/getting-started/quickstarts/nextjs

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-hook-form": "^7.52.1",
     "server-only": "^0.0.1",
     "sonner": "^1.5.0",
+    "pg": "^8.11.3",
     "superjson": "^2.2.1",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",

--- a/src/app/api/stream/user-updates/route.ts
+++ b/src/app/api/stream/user-updates/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { supabaseServer } from "~/util/supabase/server";
+import { eventBus } from "~/server/events";
+
+export async function GET() {
+  const supabase = supabaseServer();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const listener = (payload: { userId: string; fields: string[] }) => {
+        if (payload.userId === user.id) {
+          controller.enqueue(`data: ${JSON.stringify(payload)}\n\n`);
+        }
+      };
+      eventBus.on("internal-update", listener);
+      const keepAlive = setInterval(() => {
+        controller.enqueue(`:\n\n`);
+      }, 15000);
+      return () => {
+        clearInterval(keepAlive);
+        eventBus.off("internal-update", listener);
+      };
+    },
+  });
+
+  return new NextResponse(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache",
+    },
+  });
+}

--- a/src/app/api/webhooks/internal-updated/route.ts
+++ b/src/app/api/webhooks/internal-updated/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { env } from "~/env";
+import { eventBus } from "~/server/events";
+
+export async function POST(req: NextRequest) {
+  const secret = req.headers.get("x-webhook-secret");
+  if (secret !== env.N8N_WEBHOOK_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await req.json()) as {
+    user_id: string;
+    updatedFields: string[];
+  };
+
+  console.info(`[webhook] internal updated`, body);
+
+  eventBus.emit("internal-update", {
+    userId: body.user_id,
+    fields: body.updatedFields,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/n8n-demo/client-page.tsx
+++ b/src/app/n8n-demo/client-page.tsx
@@ -1,12 +1,41 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { clientApi } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
 import { toast } from "sonner";
 
 export function N8nDemoClient() {
   const [isProcessing, setIsProcessing] = useState(false);
+  const [form, setForm] = useState({ test1: "", test2: "" });
+
+  const { data, refetch } = clientApi.internal.getUserData.useQuery();
+
+  const { mutate: updateData, isLoading: updating } =
+    clientApi.internal.updateUserData.useMutation({
+      onSuccess: () => {
+        toast.success("Data updated");
+        void refetch();
+      },
+      onError: (err) => toast.error(err.message),
+    });
+
+  const { mutate: initData } = clientApi.internal.initializeUserData.useMutation({
+    onSuccess: () => {
+      toast.success("Initialized user data");
+      void refetch();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  useEffect(() => {
+    const es = new EventSource("/api/stream/user-updates");
+    es.onmessage = () => {
+      void refetch();
+    };
+    return () => es.close();
+  }, [refetch]);
 
   const { mutate: processWorkflow } = clientApi.n8n.template.processTemplate.useMutation({
     onSuccess: () => {
@@ -34,9 +63,33 @@ export function N8nDemoClient() {
           <CardTitle>n8n Workflow Demo</CardTitle>
         </CardHeader>
         <CardContent>
-          <Button onClick={handleProcessWorkflow} disabled={isProcessing} className="w-full">
+          <div className="mb-4 grid gap-2">
+            <Input
+              placeholder="test1"
+              value={form.test1}
+              onChange={(e) => setForm({ ...form, test1: e.target.value })}
+            />
+            <Input
+              placeholder="test2"
+              value={form.test2}
+              onChange={(e) => setForm({ ...form, test2: e.target.value })}
+            />
+            <Button
+              onClick={() => updateData(form)}
+              disabled={updating}
+            >
+              {updating ? "Saving..." : "Save"}
+            </Button>
+            <Button onClick={() => initData()} variant="secondary">
+              Initialize
+            </Button>
+          </div>
+          <Button onClick={handleProcessWorkflow} disabled={isProcessing} className="w-full mt-2">
             {isProcessing ? "Processing..." : "Run n8n Workflow"}
           </Button>
+          {data && (
+            <pre className="mt-4 text-sm">{JSON.stringify(data, null, 2)}</pre>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/env.js
+++ b/src/env.js
@@ -14,6 +14,7 @@ export const env = createEnv({
         (str) => !str.includes("YOUR_MYSQL_URL_HERE"),
         "You forgot to change the default URL",
       ),
+    INTERNAL_DATABASE_URL: z.string().url(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
@@ -38,6 +39,7 @@ export const env = createEnv({
    */
   runtimeEnv: {
     DATABASE_URL: process.env.DATABASE_URL,
+    INTERNAL_DATABASE_URL: process.env.INTERNAL_DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,6 @@
 import { exampleRouter } from "~/server/api/routers/example";
 import { n8nRouter } from "~/server/api/routers/n8n";
+import { internalRouter } from "~/server/api/routers/internal";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -10,6 +11,7 @@ import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 export const appRouter = createTRPCRouter({
   example: exampleRouter,
   n8n: n8nRouter,
+  internal: internalRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/internal.ts
+++ b/src/server/api/routers/internal.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { createTRPCRouter, authorizedProcedure } from "~/server/api/trpc";
+import { internalDb } from "~/server/internal-db";
+
+export const internalRouter = createTRPCRouter({
+  getUserData: authorizedProcedure.query(async ({ ctx }) => {
+    const uid = ctx.supabaseUser!.id;
+    const { rows } = await internalDb.query(
+      'SELECT "UID", "test1", "test2" FROM "userData" WHERE "UID" = $1',
+      [uid],
+    );
+    return rows[0] ?? null;
+  }),
+
+  updateUserData: authorizedProcedure
+    .input(
+      z.object({
+        test1: z.string().optional(),
+        test2: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const uid = ctx.supabaseUser!.id;
+      await internalDb.query(
+        `INSERT INTO "userData" ("UID", "test1", "test2")
+         VALUES ($1, $2, $3)
+         ON CONFLICT ("UID") DO UPDATE
+         SET "test1" = COALESCE($2, "userData"."test1"),
+             "test2" = COALESCE($3, "userData"."test2")`,
+        [uid, input.test1 ?? null, input.test2 ?? null],
+      );
+      const { rows } = await internalDb.query(
+        'SELECT "UID", "test1", "test2" FROM "userData" WHERE "UID" = $1',
+        [uid],
+      );
+      return rows[0];
+    }),
+
+  initializeUserData: authorizedProcedure.mutation(async ({ ctx }) => {
+    const uid = ctx.supabaseUser!.id;
+    await internalDb.query(
+      `INSERT INTO "userData" ("UID", "test1", "test2")
+       VALUES ($1, '', '')
+       ON CONFLICT ("UID") DO NOTHING`,
+      [uid],
+    );
+    const { rows } = await internalDb.query(
+      'SELECT "UID", "test1", "test2" FROM "userData" WHERE "UID" = $1',
+      [uid],
+    );
+    return rows[0];
+  }),
+});

--- a/src/server/events.ts
+++ b/src/server/events.ts
@@ -1,0 +1,8 @@
+import { EventEmitter } from "events";
+
+const globalForEvents = globalThis as unknown as {
+  eventBus?: EventEmitter;
+};
+
+export const eventBus =
+  globalForEvents.eventBus ?? (globalForEvents.eventBus = new EventEmitter());

--- a/src/server/internal-db.ts
+++ b/src/server/internal-db.ts
@@ -1,0 +1,14 @@
+import { Pool } from "pg";
+import { env } from "~/env";
+
+const createPool = () => new Pool({ connectionString: env.INTERNAL_DATABASE_URL });
+
+const globalForPg = globalThis as unknown as {
+  internalPool?: ReturnType<typeof createPool>;
+};
+
+export const internalDb = globalForPg.internalPool ?? createPool();
+
+if (env.NODE_ENV !== "production") {
+  globalForPg.internalPool = internalDb;
+}


### PR DESCRIPTION
## Summary
- configure internal database url in env and example file
- create pg-based internal database client and events bus
- expose internal tRPC router with userData handlers
- extend n8n demo page with user data example
- add webhook and SSE routes for user updates
- register the internal router in the tRPC root
- add `pg` runtime dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513bb032a4832caed9cfa339af462a