### PR TITLE
Add internal db integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@
 # https://www.prisma.io/docs/reference/database-reference/connection-urls#env
 DATABASE_URL="postgresql://postgres:password@localhost:5432/nextjs-supabase-template"
 
+# Internal Database
+INTERNAL_DATABASE_URL="postgresql://postgres:password@postgres.railway.internal:5432/railway"
+
 # Supabase
 # https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
 NEXT_PUBLIC_SUPABASE_URL=""

--- a/database-setup.sql
+++ b/database-setup.sql
@@ -1,0 +1,9 @@
+-- Run this against your INTERNAL_DATABASE_URL to create required table
+CREATE TABLE IF NOT EXISTS userData (
+  UID VARCHAR(255) PRIMARY KEY,
+  test1 VARCHAR(255) DEFAULT '',
+  test2 VARCHAR(255) DEFAULT ''
+);
+
+-- Create index for better performance
+CREATE INDEX IF NOT EXISTS idx_userData_UID ON userData(UID);

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,9 @@
         "superjson": "^2.2.1",
         "tailwind-merge": "^2.4.0",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "pg": "^8.11.3",
+        "@types/pg": "^8.10.2"
       },
       "devDependencies": {
         "@types/eslint": "^8.56.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "superjson": "^2.2.1",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "pg": "^8.11.3",
+    "@types/pg": "^8.10.2"
   },
   "devDependencies": {
     "@types/eslint": "^8.56.2",

--- a/src/app/api/stream/user-updates/route.ts
+++ b/src/app/api/stream/user-updates/route.ts
@@ -1,6 +1,46 @@
 import { type NextRequest } from "next/server";
-import { supabaseServer } from "~/util/supabase/server";
+import { internalDb } from "~/server/internal-db";
 
 export async function GET(req: NextRequest) {
-  return new Response(null);
+  const { searchParams } = new URL(req.url);
+  const uid = searchParams.get("uid");
+  if (!uid) return new Response("uid required", { status: 400 });
+
+  const encoder = new TextEncoder();
+  let last: string | null = null;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const interval = setInterval(async () => {
+        try {
+          const result = await internalDb.query(
+            'SELECT test1, test2 FROM "userData" WHERE "UID" = $1',
+            [uid],
+          );
+          if (result.rows[0]) {
+            const payload = JSON.stringify(result.rows[0]);
+            if (payload !== last) {
+              last = payload;
+              controller.enqueue(encoder.encode(`data: ${payload}\n\n`));
+            }
+          }
+        } catch (err) {
+          controller.enqueue(encoder.encode(`event: error\ndata: ${err}\n\n`));
+        }
+      }, 2000);
+
+      req.signal.addEventListener("abort", () => {
+        clearInterval(interval);
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+      "Cache-Control": "no-cache, no-transform",
+    },
+  });
 }

--- a/src/app/api/stream/user-updates/route.ts
+++ b/src/app/api/stream/user-updates/route.ts
@@ -1,0 +1,6 @@
+import { type NextRequest } from "next/server";
+import { supabaseServer } from "~/util/supabase/server";
+
+export async function GET(req: NextRequest) {
+  return new Response(null);
+}

--- a/src/app/api/webhooks/internal-updated/route.ts
+++ b/src/app/api/webhooks/internal-updated/route.ts
@@ -1,6 +1,25 @@
 import { type NextRequest } from "next/server";
 import { env } from "~/env";
+import { internalDb } from "~/server/internal-db";
+
+type Payload = {
+  uid: string;
+  test1?: string;
+  test2?: string;
+};
 
 export async function POST(req: NextRequest) {
+  if (req.headers.get("x-webhook-secret") !== env.N8N_WEBHOOK_SECRET) {
+    return new Response("unauthorized", { status: 401 });
+  }
+  const body = (await req.json()) as Payload;
+  if (!body.uid) {
+    return new Response("uid required", { status: 400 });
+  }
+  await internalDb.query(
+    `INSERT INTO "userData" ("UID", "test1", "test2") VALUES ($1, $2, $3)
+    ON CONFLICT("UID") DO UPDATE SET "test1" = EXCLUDED."test1", "test2" = EXCLUDED."test2"`,
+    [body.uid, body.test1 ?? "", body.test2 ?? ""],
+  );
   return new Response("ok");
 }

--- a/src/app/api/webhooks/internal-updated/route.ts
+++ b/src/app/api/webhooks/internal-updated/route.ts
@@ -1,0 +1,6 @@
+import { type NextRequest } from "next/server";
+import { env } from "~/env";
+
+export async function POST(req: NextRequest) {
+  return new Response("ok");
+}

--- a/src/app/n8n-demo/client-page.tsx
+++ b/src/app/n8n-demo/client-page.tsx
@@ -9,6 +9,24 @@ import { toast } from "sonner";
 
 export function N8nDemoClient() {
   const [isProcessing, setIsProcessing] = useState(false);
+  const [uid, setUid] = useState("demo-user");
+  const [lastUpdate, setLastUpdate] = useState<string | null>(null);
+  const [dbPing, setDbPing] = useState<string | null>(null);
+
+  const { refetch: pingInternalDb } = clientApi.internal.testConnection.useQuery(
+    undefined,
+    { enabled: false },
+  );
+
+  useEffect(() => {
+    const source = new EventSource(`/api/stream/user-updates?uid=${uid}`);
+    source.onmessage = (ev) => {
+      setLastUpdate(ev.data);
+    };
+    return () => {
+      source.close();
+    };
+  }, [uid]);
 
   const { mutate: processWorkflow } = clientApi.n8n.template.processTemplate.useMutation({
     onSuccess: () => {
@@ -29,16 +47,37 @@ export function N8nDemoClient() {
     });
   };
 
+  const handlePingDb = async () => {
+    const res = await pingInternalDb();
+    if (res.data?.timestamp) {
+      setDbPing(res.data.timestamp.toString());
+      toast.success("Internal DB connected");
+    } else {
+      toast.error("Internal DB connection failed");
+    }
+  };
+
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center">
-      <Card className="max-w-[400px]">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4">
+      <Card className="w-full max-w-[400px]">
         <CardHeader>
           <CardTitle>n8n Workflow Demo</CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-2">
           <Button onClick={handleProcessWorkflow} disabled={isProcessing} className="w-full">
             {isProcessing ? "Processing..." : "Run n8n Workflow"}
           </Button>
+          <div className="space-y-1">
+            <Label htmlFor="uid">User ID</Label>
+            <Input id="uid" value={uid} onChange={(e) => setUid(e.target.value)} />
+          </div>
+          <Button onClick={handlePingDb} type="button" className="w-full">
+            Ping Internal DB
+          </Button>
+          {dbPing && <div className="text-sm text-muted-foreground">Last ping: {dbPing}</div>}
+          {lastUpdate && (
+            <div className="text-sm text-muted-foreground">Last Update: {lastUpdate}</div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/app/n8n-demo/client-page.tsx
+++ b/src/app/n8n-demo/client-page.tsx
@@ -1,8 +1,10 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { clientApi } from "~/trpc/react";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
 import { toast } from "sonner";
 
 export function N8nDemoClient() {

--- a/src/env.js
+++ b/src/env.js
@@ -20,6 +20,7 @@ export const env = createEnv({
     N8N_BASE_URL: z.string().url(),
     N8N_WEBHOOK_SECRET: z.string().min(32),
     N8N_TIMEOUT: z.coerce.number().default(30000),
+    INTERNAL_DATABASE_URL: z.string().url(),
   },
 
   /**
@@ -44,6 +45,7 @@ export const env = createEnv({
     N8N_BASE_URL: process.env.N8N_BASE_URL,
     N8N_WEBHOOK_SECRET: process.env.N8N_WEBHOOK_SECRET,
     N8N_TIMEOUT: process.env.N8N_TIMEOUT,
+    INTERNAL_DATABASE_URL: process.env.INTERNAL_DATABASE_URL,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,6 @@
 import { exampleRouter } from "~/server/api/routers/example";
 import { n8nRouter } from "~/server/api/routers/n8n";
+import { internalRouter } from "~/server/api/routers/internal";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -10,6 +11,7 @@ import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 export const appRouter = createTRPCRouter({
   example: exampleRouter,
   n8n: n8nRouter,
+  internal: internalRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/internal.ts
+++ b/src/server/api/routers/internal.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import { authorizedProcedure, createTRPCRouter } from "~/server/api/trpc";
 import { internalDb } from "~/server/internal-db";
 import { TRPCError } from "@trpc/server";

--- a/src/server/api/routers/internal.ts
+++ b/src/server/api/routers/internal.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { authorizedProcedure, createTRPCRouter } from "~/server/api/trpc";
+import { internalDb } from "~/server/internal-db";
+import { TRPCError } from "@trpc/server";
+
+export const internalRouter = createTRPCRouter({
+  testConnection: authorizedProcedure.query(async () => {
+    try {
+      const result = await internalDb.query('SELECT NOW()');
+      return { success: true, timestamp: result.rows[0] };
+    } catch (error) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Database connection failed",
+      });
+    }
+  }),
+});

--- a/src/server/internal-db.ts
+++ b/src/server/internal-db.ts
@@ -1,0 +1,16 @@
+import { Pool } from "pg";
+import { env } from "~/env";
+
+const createInternalDbClient = () =>
+  new Pool({
+    connectionString: env.INTERNAL_DATABASE_URL,
+  });
+
+const globalForInternalDb = globalThis as unknown as {
+  internalDb: Pool | undefined;
+};
+
+export const internalDb =
+  globalForInternalDb.internalDb ?? createInternalDbClient();
+
+if (env.NODE_ENV !== "production") globalForInternalDb.internalDb = internalDb;


### PR DESCRIPTION
## Summary
- add `pg` database packages
- add INTERNAL_DATABASE_URL to env config and example env file
- create internal database client and TRPC router
- wire internal router into API root
- prepare database setup script
- scaffold webhook handler and SSE route
- update n8n demo imports

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'eslint')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685145674d00832c863e38e23b6d9bb0